### PR TITLE
Fix loading of RSA key

### DIFF
--- a/ssh_utilities/remote/remote.py
+++ b/ssh_utilities/remote/remote.py
@@ -281,6 +281,7 @@ class SSHConnection(ConnectionABC):
                 self._pkey = key.from_private_key_file(
                     self._path2str(self.pkey_file)
                 )
+                break
             except paramiko.SSHException:
                 log.info(f"could not parse key with {key.__name__}")        
 


### PR DESCRIPTION
Don't try other algorithms if a valid key was already found

This fixes the issue that the following exception is thrown when trying to connect with an RSA key:
"q must be exactly 160, 224, or 256 bits long"
(observed with paramiko versions 2.11 and 2.12)

This fixes the implementation that was originally introduced with commig 90f5284669.